### PR TITLE
custom key prefixes for easier key management

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,8 +6,5 @@ AllCops:
 Metrics/MethodLength:
   Max: 15
 
-Metrics/AbcSize:
-  Max: 16
-
 Metrics/LineLength:
   Max: 100

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -147,4 +147,40 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     assert_equal 1, primary.keys.count
     assert_equal 0, replica.keys.count
   end
+
+  def test_default_key_prefix_custom
+    Cache.default_key_prefix = 'hello'
+
+    Cache.new { 'hello world' }
+    assert_match(/^hello/, redis.keys.first)
+  end
+
+  def test_default_key_prefix_method_name
+    Cache.default_key_prefix = :method_name
+
+    Cache.new { 'hello world' }
+    assert_match(/^test_default_key_prefix_method_name/, redis.keys.first)
+  end
+
+  def test_default_key_prefix_class_name
+    Cache.default_key_prefix = :class_name
+
+    Cache.new { 'hello world' }
+    assert_match(/^CacheTest/, redis.keys.first)
+  end
+
+  def test_key_prefix_custom
+    Cache.new(key_prefix: 'hello') { 'hello world' }
+    assert_match(/^hello/, redis.keys.first)
+  end
+
+  def test_key_prefix_method_name
+    Cache.new(key_prefix: :method_name) { 'hello world' }
+    assert_match(/^test_key_prefix_method_name/, redis.keys.first)
+  end
+
+  def test_key_prefix_class_name
+    Cache.new(key_prefix: :class_name) { 'hello world' }
+    assert_match(/^CacheTest/, redis.keys.first)
+  end
 end


### PR DESCRIPTION
cc: @jurriaan @eterps

#### key prefixes

By default, the eventual key ending up in Redis is a 6-character long digest,
based on the file name, line number, and optional key passed into the Cache
object:

```ruby
Cache.new { 'hello world' }
Cache.backend.keys # => ["22abcc"]
```

This makes working with keys quick and easy, without worying about conflicting
keys.

However, this does make it more difficult to selectively delete keys from the
backend, if you want to purge the cache of specific keys, before their TTL
expires.

To support this use-case, you can use the `key_prefix` attribute:

```ruby
Cache.new(key_prefix: 'hello') { 'hello world' }
Cache.backend.keys # => ["hello_22abcc"]
```

This allows you to selectively purge keys from Redis:

```ruby
Cache.backend.del('hello_')
```

You can also use the special value `:method_name` to dynamically set the key
prefix based on where the cached object was created:

```ruby
Cache.new(key_prefix: :method_name) { 'hello world' }
Cache.backend.keys # => ["test_key_prefix_method_name_22abcc"]
```

Or, use `:class_name` to group keys in the same class together:

```ruby
Cache.new(key_prefix: :class_name) { 'hello world' }
Cache.backend.keys # => ["CacheTest_22abcc"]
```

You can also define this option globally:

```ruby
Cache.default_key_prefix = :class_name
```
