### PR TITLE
Fix some small issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
     - '.wercker/**/*'
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
 
 Metrics/LineLength:
   Max: 100

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,13 @@ Metrics/MethodLength:
 
 Metrics/LineLength:
   Max: 100
+
+Lint/RescueWithoutErrorClass:
+  Exclude:
+    - 'lib/object/cache.rb'
+    - 'test/cache_test.rb'
+
+Security/MarshalLoad:
+  Exclude:
+    - 'lib/object/cache.rb'
+    - 'test/cache_test.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ from the primary instance.
 
 #### core extension
 
-Finally, if you want, you can extend `Object` with a `cache` method, for
-convenient access to the cache object:
+Finally, if you want, you can use the `cache` method, for convenient
+access to the cache object:
 
 ```ruby
 require 'object/cache/core_extension'
@@ -219,15 +219,6 @@ require 'object/cache/core_extension'
 # these are the same:
 cache('hello', ttl: 60) { 'hello world' }
 Cache.new('hello', ttl: 60) { 'hello world' }
-```
-
-You can also call this method directly on any instances inheriting from
-`Object`:
-
-```ruby
-require 'object/cache/core_extension'
-
-'hello world'.cache(ttl: 60)
 ```
 
 That's it!

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new do |t|
-  t.options = %w(--display-cop-names --extra-details --display-style-guide)
+  t.options = %w[--display-cop-names --extra-details --display-style-guide]
 end
 
 Rake::TestTask.new(:test) do |t|
@@ -13,4 +14,4 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task default: %i(test rubocop)
+task default: %i[test rubocop]

--- a/lib/object/cache.rb
+++ b/lib/object/cache.rb
@@ -107,8 +107,8 @@ class Cache
     def build_key_prefix(key_prefix, proc)
       case key_prefix
       when :method_name
-        location = caller_locations.find { |l| "#{l.path}#{l.lineno}" == proc.source_location.join }
-        location && location.base_label
+        location = caller_locations.find { |l| proc.source_location.join == "#{l.path}#{l.lineno}" }
+        location&.base_label
       when :class_name
         proc.binding.receiver.class.to_s
       else

--- a/lib/object/cache.rb
+++ b/lib/object/cache.rb
@@ -63,7 +63,12 @@ class Cache
             end
           end
         else
-          Marshal.load(cached_value)
+          begin
+            Marshal.load(cached_value)
+          rescue
+            delete(key)
+            yield
+          end
         end
       end
     end

--- a/lib/object/cache/core_extension.rb
+++ b/lib/object/cache/core_extension.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'object/cache'
 
 # :no-doc:

--- a/lib/object/cache/core_extension.rb
+++ b/lib/object/cache/core_extension.rb
@@ -3,10 +3,8 @@
 require 'object/cache'
 
 # :no-doc:
-class Object
+module Kernel
   def cache(key = nil, **options, &block)
-    block = -> { self } unless block_given?
-
     Cache.new(key, **options, &block)
   end
 end

--- a/object-cache.gemspec
+++ b/object-cache.gemspec
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 # encoding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'object/cache'
@@ -7,15 +8,15 @@ require 'object/cache'
 Gem::Specification.new do |spec|
   spec.name          = 'object-cache'
   spec.version       = Cache::VERSION
-  spec.authors       = %w(Jean Mertz)
-  spec.email         = %w(jean@mertz.fm)
+  spec.authors       = %w[Jean Mertz]
+  spec.email         = %w[jean@mertz.fm]
 
   spec.summary       = 'Caching of objects, using a Redis store.'
   spec.description   = 'Easily cache objects in Ruby, using a Redis store backend'
   spec.homepage      = 'https://github.com/blendle/object-cache'
   spec.license       = 'MIT'
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.require_paths = %w(lib)
+  spec.require_paths = %w[lib]
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'm', '~> 1.5'

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -190,6 +190,7 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     val = 0
     block = -> { val += 1 }
     Cache.new(&block)
+    Cache.backend = MockRedis.new
 
     assert_equal 1, val
   end
@@ -206,6 +207,7 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
       nil
     end
 
+    Cache.backend = MockRedis.new
     assert_equal 1, val
   end
 end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'mock_redis'
@@ -21,7 +22,7 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   end
 
   def test_cache_returns_object
-    assert_equal 'hello world', Cache.new { 'hello world' }
+    assert_equal('hello world', Cache.new { 'hello world' })
   end
 
   def test_cache_stores_object
@@ -94,7 +95,7 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
 
   def test_core_extension
     load 'object/cache/core_extension.rb'
-    assert_equal 'hello world', cache { 'hello world' }
+    assert_equal('hello world', cache { 'hello world' })
     assert Object.send(:remove_method, :cache)
   end
 

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -210,4 +210,18 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     Cache.backend = MockRedis.new
     assert_equal 1, val
   end
+
+  def test_single_yield_on_failure
+    val = 0
+    begin
+      Cache.new do
+        val += 1
+        raise TypeError
+      end
+    rescue
+      nil
+    end
+
+    assert_equal 1, val
+  end
 end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -224,4 +224,13 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
 
     assert_equal 1, val
   end
+
+  def test_yield_when_marshal_load_fails
+    testing = -> { Cache.new(key_prefix: 'marshal') { 'hello world' } }
+
+    assert_equal 'hello world', testing.call
+    redis.set(redis.keys('marshal*').first, 'garbage')
+    assert_equal 'hello world', testing.call
+    assert_empty redis.keys('marshal*')
+  end
 end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -184,4 +184,13 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
     Cache.new(key_prefix: :class_name) { 'hello world' }
     assert_match(/^CacheTest/, redis.keys.first)
   end
+
+  def test_unset_backend
+    Cache.backend = nil
+    val = 0
+    block = -> { val += 1 }
+    Cache.new(&block)
+
+    assert_equal 1, val
+  end
 end

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -96,27 +96,14 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
   def test_core_extension
     load 'object/cache/core_extension.rb'
     assert_equal('hello world', cache { 'hello world' })
-    assert Object.send(:remove_method, :cache)
+    assert Kernel.send(:remove_method, :cache)
   end
 
   def test_core_extension_options
     load 'object/cache/core_extension.rb'
     cache(ttl: 60) { 'hello world' }
     assert_equal 60, redis.ttl(redis.keys.first)
-    assert Object.send(:remove_method, :cache)
-  end
-
-  def test_core_extension_on_objects
-    load 'object/cache/core_extension.rb'
-    assert_equal 'hello world', 'hello world'.cache
-    assert Object.send(:remove_method, :cache)
-  end
-
-  def test_core_extension_on_objects_with_arguments
-    load 'object/cache/core_extension.rb'
-    'hello world'.cache(ttl: 30)
-    assert_equal 30, redis.ttl(redis.keys.first)
-    assert Object.send(:remove_method, :cache)
+    assert Kernel.send(:remove_method, :cache)
   end
 
   def test_backend_with_replicas

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -193,4 +193,19 @@ class CacheTest < Minitest::Test # rubocop:disable Metrics/ClassLength
 
     assert_equal 1, val
   end
+
+  def test_unset_backend_raising_type_error
+    Cache.backend = nil
+    val = 0
+    begin
+      Cache.new do
+        val += 1
+        raise TypeError
+      end
+    rescue
+      nil
+    end
+
+    assert_equal 1, val
+  end
 end


### PR DESCRIPTION
Fixes a few problems:

- Do not catch Exceptions when there's no replica
- Fix second yield when an exception occurs during first yield
- Yield and delete key when Marshal.load fails
- Removes support for calling cache on values

Fixes https://github.com/blendle/object-cache/issues/4