### PR TITLE
Loosen development dependency constraints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - '.wercker/**/*'
 

--- a/object-cache.gemspec
+++ b/object-cache.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'm', '~> 1.5'
-  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mock_redis', '~> 0.16'
-  spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.40'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rubocop'
 end


### PR DESCRIPTION
>The rubocop dependency defined in object-cache.gemspec has a known low severity security vulnerability in version range < 0.48.1 and should be updated.

This restriction was causing us to use a vulnerable version of RuboCop. I have loosened the constraints of a few of the development dependencies.