### PR TITLE
Reduce the chances of hash collisions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ Metrics/MethodLength:
 Metrics/LineLength:
   Max: 100
 
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Exclude:
     - 'lib/object/cache.rb'
     - 'test/cache_test.rb'

--- a/lib/object/cache.rb
+++ b/lib/object/cache.rb
@@ -106,7 +106,7 @@ class Cache
     end
 
     def build_key(key, key_prefix, proc)
-      hash   = Digest::SHA1.hexdigest([key, proc.source_location].flatten.join)[0..5]
+      hash   = Digest::SHA1.hexdigest([key, proc.source_location].flatten.join)[0..11]
       prefix = build_key_prefix(key_prefix, proc)
 
       [prefix, hash].compact.join('_')

--- a/lib/object/cache/version.rb
+++ b/lib/object/cache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Cache
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/object-cache.gemspec
+++ b/object-cache.gemspec
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
-# encoding: utf-8
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'object/cache'
 

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'mock_redis'
 require 'object/cache'


### PR DESCRIPTION
Use the first 6 bytes of the hash, instead of just the first 3.

This reduces chances of hash collisions, which were pretty significant
when having > 1000 values in cache.