### PR TITLE
Fix proc without block deprecation warning.

### DIFF
--- a/lib/object/cache.rb
+++ b/lib/object/cache.rb
@@ -44,11 +44,11 @@ class Cache
     #   Cache.new { item } # item is only stored once, and then always
     #                      # retrieved, even if it is a different item
     #
-    def new(key = nil, ttl: default_ttl, key_prefix: default_key_prefix)
+    def new(key = nil, ttl: default_ttl, key_prefix: default_key_prefix, &block)
       return yield unless replica
 
       begin
-        key = build_key(key, key_prefix, Proc.new)
+        key = build_key(key, key_prefix, block)
 
         if (cached_value = replica.get(key)).nil?
           yield.tap do |value|


### PR DESCRIPTION
Ruby 2.7 added a warning for Proc.new without block. See https://blog.saeloun.com/2019/09/02/ruby-2-7-proc-without-block-warning.html.