### PR TITLE
update from exist to exists?

### DIFF
--- a/lib/object/cache.rb
+++ b/lib/object/cache.rb
@@ -74,7 +74,7 @@ class Cache
     end
 
     def include?(key)
-      replica.exists(key)
+      replica.exists?(key)
     rescue
       false
     end


### PR DESCRIPTION



Exist will return a integer in the future, the new way is using `exist?`


But I think we have a ticket to update everything to Rails cache instead, so this might be redundant.