### PR TITLE
Fix deprecation warning in Ruby 2.7

### DIFF
--- a/lib/object/cache.rb
+++ b/lib/object/cache.rb
@@ -44,11 +44,11 @@ class Cache
     #   Cache.new { item } # item is only stored once, and then always
     #                      # retrieved, even if it is a different item
     #
-    def new(key = nil, ttl: default_ttl, key_prefix: default_key_prefix)
+    def new(key = nil, ttl: default_ttl, key_prefix: default_key_prefix, &block)
       return yield unless replica
 
       begin
-        key = build_key(key, key_prefix, Proc.new)
+        key = build_key(key, key_prefix, block)
 
         if (cached_value = replica.get(key)).nil?
           yield.tap do |value|


### PR DESCRIPTION
`Proc.new` without a block silently captures the block, this behavior has
been deprecated, and you should use `&block` instead.

See https://blog.saeloun.com/2019/09/02/ruby-2-7-proc-without-block-warning.html for more information.